### PR TITLE
Fixes Leap repetitions ("openSUSE Leap Leap 42.2")

### DIFF
--- a/slideshow.xml
+++ b/slideshow.xml
@@ -17,7 +17,7 @@
   <title>Welcome to openSUSE™!</title>
 
     <para>
-openSUSE is the makers' choice for sysadmins, developers and desktop users because it gives you more choices than other distributions. openSUSE Leap combines proven core packages from SUSE Linux Enterprise with community built packages, which creates synergies for the project's distribution. Get the Best of Both Worlds with openSUSE Leap. openSUSE releases provide users a feature-rich server environments and user-friendly desktop. Enthusiasts and professionals looking for a long-term, highly stable Linux system need to look no further than openSUSE Leap &suse-version;, which complements the latest SUSE Linux Enterprise due to the shared sources. Thank you for making the change to use the most dependable and stable Linux system - openSUSE Leap &suse-version;.
+openSUSE is the makers' choice for sysadmins, developers and desktop users because it gives you more choices than other distributions. openSUSE Leap combines proven core packages from SUSE Linux Enterprise with community built packages, which creates synergies for the project's distribution. Get the Best of Both Worlds with openSUSE Leap. openSUSE releases provide users a feature-rich server environments and user-friendly desktop. Enthusiasts and professionals looking for a long-term, highly stable Linux system need to look no further than openSUSE &suse-version;, which complements the latest SUSE Linux Enterprise due to the shared sources. Thank you for making the change to use the most dependable and stable Linux system - openSUSE &suse-version;.
 </para>
  </section>
 
@@ -54,7 +54,7 @@ the Web, including the newest HTML5 technologies. Firefox also boasts
 lightning-fast performance, and a number of improvements designed to
 protect your privacy and prevent phishing attacks.</para>
 
-<para>Also included with openSUSE Leap &suse-version; are Evolution and Kontact, 
+<para>Also included with openSUSE &suse-version; are Evolution and Kontact, 
 complete e-mail and contact management applications. For instant 
 messaging, openSUSE features easy to use IM clients that support all 
 of the popular protocols.</para> 
@@ -64,7 +64,7 @@ of the popular protocols.</para>
  <section label="04_create">
   <title>Developers and Sysadmins</title>
   <para>
-openSUSE Leap &suse-version; and openSUSE Tumbleweed are great distributions for development, testing and deployment. Whether you need the latest packages, which can be found on Tumbleweed, or more stable packages, which can be found on Leap &suse-version;, openSUSE gives you the tools, community and packages needed to be sucessful.</para>
+openSUSE &suse-version; and openSUSE Tumbleweed are great distributions for development, testing and deployment. Whether you need the latest packages, which can be found on Tumbleweed, or more stable packages, which can be found on &suse-version;, openSUSE gives you the tools, community and packages needed to be sucessful.</para>
 
  </section>
 


### PR DESCRIPTION
&suse-version; already includes Leap, so removed "Leap" before
each &suse-version; entity.

Closes #4 
